### PR TITLE
Add websocket osm-p2p-db replication to web server

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2,30 +2,60 @@
 const db = require('./db')
 const bodyParser = require('body-parser')
 const express = require('express')
-const routes = express()
-const server = require('http').createServer(routes)
+const http = require('http')
+const websocket = require('websocket-stream')
+const eos = require('end-of-stream')
 
-module.exports = {
-  listen
+function Server (opts) {
+  if (!(this instanceof Server)) return new Server(opts)
+
+  opts = opts || {}
+  opts.port = opts.port || 3210
+
+  const routes = express()
+  const server = http.createServer(routes)
+
+  websocket.createServer({
+    perMessageDeflate: false,
+    server: server
+  }, handleWebsocketStream)
+
+  this.listen = function () {
+    server.listen(opts.port)
+  }
+
+  routes.get('/observations/list', function (req, res) {
+    db.listObservations(function (err, features) {
+      if (err) return res.status(500).send(err.message)
+      res.send(JSON.stringify(features))
+    })
+  })
+
+  const jsonParser = bodyParser.json()
+  routes.put('/observations/create', jsonParser, function (req, res) {
+    if (!req.body) return res.sendStatus(400)
+    db.createObservation(req.body, function (err) {
+      if (err) return res.status(500).send(err.message)
+      res.send(req.body)
+    })
+  })
+
+  // osm-p2p-db replication endpoint
+  function handleWebsocketStream (stream) {
+    console.log('got a stream')
+    var rs = db.createOsmReplicationStream()
+    rs.pipe(stream).pipe(rs)
+
+    let pending = 2
+    eos(stream, done)
+    eos(rs, done)
+
+    function done (err) {
+      if (--pending !== 0) return
+      if (err) console.trace('replication failure', err)
+      else console.log('replication success')
+    }
+  }
 }
 
-const CONFIG = { port: 3210 }
-function listen () {
-  server.listen(CONFIG.port)
-}
-
-routes.get('/observations/list', function (req, res) {
-  db.listObservations(function (err, features) {
-    if (err) return res.status(500).send(err.message)
-    res.send(JSON.stringify(features))
-  })
-})
-
-const jsonParser = bodyParser.json()
-routes.put('/observations/create', jsonParser, function (req, res) {
-  if (!req.body) return res.sendStatus(400)
-  db.createObservation(req.body, function (err) {
-    if (err) return res.status(500).send(err.message)
-    res.send(req.body)
-  })
-})
+module.exports = Server

--- a/main.js
+++ b/main.js
@@ -3,7 +3,7 @@
 const path = require('path')
 const mkdirp = require('mkdirp')
 const db = require('./lib/db')
-const server = require('./lib/server')
+const Server = require('./lib/server')
 const settings = require('electron-settings')
 const electron = require('electron')
 const app = electron.app
@@ -45,6 +45,8 @@ mkdirp.sync(userDataPath)
 const dbPath = path.join(userDataPath, 'db')
 mkdirp.sync(dbPath)
 db.start(dbPath)
+
+var server = new Server()
 server.listen()
 
 app.on('ready', init)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "body-parser": "^1.17.2",
+    "end-of-stream": "^1.4.0",
     "es6-promisify": "^5.0.0",
     "express": "^4.15.3",
     "immutable": "^3.8.1",
@@ -55,6 +56,7 @@
     "redux": "^3.6.0",
     "redux-saga": "^0.15.3",
     "through2": "^2.0.3",
-    "turf-extent": "^1.0.4"
+    "turf-extent": "^1.0.4",
+    "websocket-stream": "^5.0.0"
   }
 }


### PR DESCRIPTION
The mobile client will be able to connect to this endpoint via a websocket and
perform osm-p2p-db replication.

I also refactored `lib/server.js` a little to contain its state within an
object, so that a new server isn't created every time someone `require`s it.