### PR TITLE
Add osm-p2p network replication

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -23,9 +23,7 @@ let observationsIndex
 function start (rootDir) {
   if (typeof osmOrgDb === 'undefined' && typeof observationsDb === 'undefined' && typeof observationsIndex === 'undefined') {
     osmOrgDb = osmdb(path.join(rootDir, 'osmOrgDb'))
-
     observationsDb = osmdb(path.join(rootDir, 'observationsDb'))
-
     var obsdb = level(path.join(rootDir, 'observationsIndex'))
     observationsIndex = osmobs({ db: obsdb, log: observationsDb.log })
   }
@@ -61,11 +59,13 @@ function createObservation (feature, cb) {
 
 function listObservations (cb) {
   var features = []
-  pump(observationsDb.kv.createReadStream(), through.obj(write), done)
+
+  observationsDb.ready(function () {
+    pump(observationsDb.kv.createReadStream(), through.obj(write), done)
+  })
 
   function write (row, enc, next) {
-    var values = Object.keys(row.values || {})
-    .map(v => row.values[v])
+    var values = Object.keys(row.values || {}).map(v => row.values[v])
     if (values.length && get(values, '0.value.type') === 'observation') {
       var latest = values.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0))[0]
       features.push(observationToFeature(latest.value, row.key))

--- a/lib/db.js
+++ b/lib/db.js
@@ -10,7 +10,8 @@ const { get } = require('object-path')
 
 module.exports = {
   start,
-  createOsmReplicationStream,
+  createOsmOrgReplicationStream,
+  createObservationsReplicationStream,
   createObservation,
   listObservations
 }

--- a/lib/db.js
+++ b/lib/db.js
@@ -15,17 +15,27 @@ module.exports = {
   listObservations
 }
 
-let osm, obs
-function start (osmdir) {
-  if (typeof osm === 'undefined' && typeof obs === 'undefined') {
-    var obsdb = level(path.join(osmdir, 'obsdb'))
-    osm = osmdb(osmdir)
-    obs = osmobs({ db: obsdb, log: osm.log })
+let osmOrgDb
+let observationsDb
+let observationsIndex
+
+function start (rootDir) {
+  if (typeof osmOrgDb === 'undefined' && typeof observationsDb === 'undefined' && typeof observationsIndex === 'undefined') {
+    osmOrgDb = osmdb(path.join(rootDir, 'osmOrgDb'))
+
+    observationsDb = osmdb(path.join(rootDir, 'observationsDb'))
+
+    var obsdb = level(path.join(rootDir, 'observationsIndex'))
+    observationsIndex = osmobs({ db: obsdb, log: observationsDb.log })
   }
 }
 
-function createOsmReplicationStream () {
-  return osm.log.replicate()
+function createOsmOrgReplicationStream () {
+  return osmOrgDb.log.replicate()
+}
+
+function createObservationsReplicationStream () {
+  return observationsDb.log.replicate()
 }
 
 function createObservation (feature, cb) {
@@ -45,12 +55,12 @@ function createObservation (feature, cb) {
     obs.lat = feature.geometry.coordinates[1]
   }
   var id = feature.id || '' + randomBytes(8).toString('hex')
-  osm.put(id, obs, cb)
+  observationsDb.put(id, obs, cb)
 }
 
 function listObservations (cb) {
   var features = []
-  pump(osm.kv.createReadStream(), through.obj(write), done)
+  pump(observationsDb.kv.createReadStream(), through.obj(write), done)
 
   function write (row, enc, next) {
     var values = Object.keys(row.values || {})

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,13 +1,10 @@
 'use strict'
 
-const http = require('http')
 const path = require('path')
 
 const bodyParser = require('body-parser')
 const { app: electronApp } = require('electron')
-const eos = require('end-of-stream')
 const express = require('express')
-const websocket = require('websocket-stream')
 
 const db = require('./db')
 const { listSurveys, readSurvey } = require('./surveys')
@@ -18,17 +15,11 @@ function Server (opts) {
   opts = opts || {}
   opts.port = opts.port || 3210
 
-  const routes = express()
-  routes.use(bodyParser.json())
-  const server = http.createServer(routes)
-
-  websocket.createServer({
-    perMessageDeflate: false,
-    server: server
-  }, handleWebsocketStream)
+  const app = express()
+  app.use(bodyParser.json())
 
   this.listen = function () {
-    server.listen(opts.port, function () {
+    app.listen(opts.port, function () {
       console.log(
         'Listening at http://%s:%d',
         this.address().address,
@@ -38,7 +29,7 @@ function Server (opts) {
   }
 
   // list observations
-  routes.get('/observations/list', function (req, res, next) {
+  app.get('/observations/list', function (req, res, next) {
     return db.listObservations(function (err, features) {
       if (err) {
         return next(err)
@@ -49,7 +40,7 @@ function Server (opts) {
   })
 
   // create new observations
-  routes.put('/observations/create', function (req, res, next) {
+  app.put('/observations/create', function (req, res, next) {
     if (!req.body) return res.sendStatus(400)
 
     return db.createObservation(req.body, function (err) {
@@ -62,7 +53,7 @@ function Server (opts) {
   })
 
   // list survey definitions
-  routes.get('/surveys/list', function (req, res, next) {
+  app.get('/surveys/list', function (req, res, next) {
     return listSurveys(function (err, surveys) {
       if (err) {
         return next(err)
@@ -77,7 +68,7 @@ function Server (opts) {
   })
 
   // get a survey definition
-  routes.get('/surveys/:id', function (req, res, next) {
+  app.get('/surveys/:id', function (req, res, next) {
     return readSurvey(req.params.id, (err, survey) => {
       if (err) {
         return next(err)
@@ -88,7 +79,7 @@ function Server (opts) {
   })
 
   // get a survey bundle
-  routes.get('/surveys/:id/bundle', function (req, res, next) {
+  app.get('/surveys/:id/bundle', function (req, res, next) {
     res.set('Content-Type', 'application/gzip')
     return res.sendFile(
       path.join(
@@ -98,23 +89,6 @@ function Server (opts) {
       )
     )
   })
-
-  // osm-p2p-db replication endpoint
-  function handleWebsocketStream (stream) {
-    console.log('got a stream')
-    var rs = db.createOsmReplicationStream()
-    rs.pipe(stream).pipe(rs)
-
-    let pending = 2
-    eos(stream, done)
-    eos(rs, done)
-
-    function done (err) {
-      if (--pending !== 0) return
-      if (err) console.trace('replication failure', err)
-      else console.log('replication success')
-    }
-  }
 }
 
 module.exports = Server

--- a/lib/server.js
+++ b/lib/server.js
@@ -8,6 +8,7 @@ const express = require('express')
 const expressWs = require('express-ws')
 const websocketStreamify = require('websocket-stream')
 const Bonjour = require('bonjour')
+const eos = require('end-of-stream')
 
 const db = require('./db')
 const { listSurveys, readSurvey } = require('./surveys')
@@ -35,13 +36,14 @@ function Server (opts) {
 
       bonjour = Bonjour()
       var serviceOpts = {
-        name: 'org.osm-labs.field-data-coordinator-' + Math.random().toString().substring(5),
+        name: 'field-data-coordinator-' + Math.random().toString().substring(5),
         type: 'osm-sync',
         port: opts.port
       }
       bonjourService = bonjour.publish(serviceOpts)
       bonjourService.start()
       bonjourService.on('up', () => console.log('service up'))
+      bonjourService.on('down', () => console.log('service down'))
       bonjourService.on('error', (err) => console.log('service err', err))
     })
   }
@@ -110,19 +112,16 @@ function Server (opts) {
 
   app.ws('/replicate/observations', function (ws) {
     var stream = websocketStreamify(ws)
-    console.log('replication shall begin!')
-    handleWebsocketStream(stream, db.createOsmOrgReplicationStream(), err => {
-      console.log('replication is done')
-      db.listObservations((err, observations) => {
-        console.log('maybe listObservations err', err)
-        console.log('observations', observations)
-      })
+    handleWebsocketStream(stream, db.createObservationsReplicationStream(), err => {
+      if (err) console.error('replication error', err)
     })
   })
 
   app.ws('/replicate/osm', function (ws) {
     var stream = websocketStreamify(ws)
-    handleWebsocketStream(stream, db.createObservationsReplicationStream())
+    handleWebsocketStream(stream, db.createOsmOrgReplicationStream(), err => {
+      if (err) console.error('replication error', err)
+    })
   })
 
   // Replication endpoint to a specific osm-p2p-db
@@ -134,10 +133,8 @@ function Server (opts) {
     eos(stream, onFinished)
     eos(rs, onFinished)
 
-    stream.on('data', console.log)
-    rs.on('data', console.log)
-
     function onFinished (err) {
+      console.log('one side finished replicating')
       if (--pending !== 0) return
       if (err) console.trace('replication failure', err)
       else console.log('replication success')

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ const { app: electronApp } = require('electron')
 const express = require('express')
 const expressWs = require('express-ws')
 const websocketStreamify = require('websocket-stream')
+const Bonjour = require('bonjour')
 
 const db = require('./db')
 const { listSurveys, readSurvey } = require('./surveys')
@@ -21,6 +22,9 @@ function Server (opts) {
   expressWs(app)
   app.use(bodyParser.json())
 
+  let bonjour
+  let bonjourService
+
   this.listen = function () {
     app.listen(opts.port, function () {
       console.log(
@@ -28,6 +32,17 @@ function Server (opts) {
         this.address().address,
         this.address().port
       )
+
+      bonjour = Bonjour()
+      var serviceOpts = {
+        name: 'org.osm-labs.field-data-coordinator-' + Math.random().toString().substring(5),
+        type: 'osm-sync',
+        port: opts.port
+      }
+      bonjourService = bonjour.publish(serviceOpts)
+      bonjourService.start()
+      bonjourService.on('up', () => console.log('service up'))
+      bonjourService.on('error', (err) => console.log('service err', err))
     })
   }
 
@@ -95,7 +110,14 @@ function Server (opts) {
 
   app.ws('/replicate/observations', function (ws) {
     var stream = websocketStreamify(ws)
-    handleWebsocketStream(stream, db.createOsmOrgReplicationStream())
+    console.log('replication shall begin!')
+    handleWebsocketStream(stream, db.createOsmOrgReplicationStream(), err => {
+      console.log('replication is done')
+      db.listObservations((err, observations) => {
+        console.log('maybe listObservations err', err)
+        console.log('observations', observations)
+      })
+    })
   })
 
   app.ws('/replicate/osm', function (ws) {
@@ -104,18 +126,22 @@ function Server (opts) {
   })
 
   // Replication endpoint to a specific osm-p2p-db
-  function handleWebsocketStream (stream, rs) {
+  function handleWebsocketStream (stream, rs, done) {
     console.log('got a replication stream')
     rs.pipe(stream).pipe(rs)
 
     let pending = 2
-    eos(stream, done)
-    eos(rs, done)
+    eos(stream, onFinished)
+    eos(rs, onFinished)
 
-    function done (err) {
+    stream.on('data', console.log)
+    rs.on('data', console.log)
+
+    function onFinished (err) {
       if (--pending !== 0) return
       if (err) console.trace('replication failure', err)
       else console.log('replication success')
+      if (done) done(err)
     }
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,6 +5,8 @@ const path = require('path')
 const bodyParser = require('body-parser')
 const { app: electronApp } = require('electron')
 const express = require('express')
+const expressWs = require('express-ws')
+const websocketStreamify = require('websocket-stream')
 
 const db = require('./db')
 const { listSurveys, readSurvey } = require('./surveys')
@@ -16,6 +18,7 @@ function Server (opts) {
   opts.port = opts.port || 3210
 
   const app = express()
+  expressWs(app)
   app.use(bodyParser.json())
 
   this.listen = function () {
@@ -89,6 +92,28 @@ function Server (opts) {
       )
     )
   })
+
+  app.ws('/replicate/observations', function (ws) {
+    var stream = websocketStreamify(ws)
+    handleWebsocketStream(stream)
+  })
+
+  // Replication endpoint to the osm-p2p-db
+  function handleWebsocketStream (stream) {
+    console.log('got a replication stream')
+    var rs = db.createOsmReplicationStream()
+    rs.pipe(stream).pipe(rs)
+
+    let pending = 2
+    eos(stream, done)
+    eos(rs, done)
+
+    function done (err) {
+      if (--pending !== 0) return
+      if (err) console.trace('replication failure', err)
+      else console.log('replication success')
+    }
+  }
 }
 
 module.exports = Server

--- a/lib/server.js
+++ b/lib/server.js
@@ -95,13 +95,17 @@ function Server (opts) {
 
   app.ws('/replicate/observations', function (ws) {
     var stream = websocketStreamify(ws)
-    handleWebsocketStream(stream)
+    handleWebsocketStream(stream, db.createOsmOrgReplicationStream())
   })
 
-  // Replication endpoint to the osm-p2p-db
-  function handleWebsocketStream (stream) {
+  app.ws('/replicate/osm', function (ws) {
+    var stream = websocketStreamify(ws)
+    handleWebsocketStream(stream, db.createObservationsReplicationStream())
+  })
+
+  // Replication endpoint to a specific osm-p2p-db
+  function handleWebsocketStream (stream, rs) {
     console.log('got a replication stream')
-    var rs = db.createOsmReplicationStream()
     rs.pipe(stream).pipe(rs)
 
     let pending = 2

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "JSONStream": "^1.3.1",
     "async": "^2.4.1",
     "body-parser": "^1.17.2",
+    "bonjour": "^3.5.0",
     "drag-drop": "^2.13.2",
     "end-of-stream": "^1.4.0",
     "es6-promisify": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "end-of-stream": "^1.4.0",
     "es6-promisify": "^5.0.0",
     "express": "^4.15.3",
+    "express-ws": "^3.0.0",
     "immutable": "^3.8.1",
     "level": "^1.7.0",
     "mapbox-gl": "^0.37.0",


### PR DESCRIPTION
- [x] Remove old websocket code and 'http' use.
- [x] Add websocket replication via express middleware.
- [x] Split osm-p2p DBs into OSM.org data, observations.
- [x] Add replication endpoints for both osm-p2p DBs.
- [x] Integration testing

Best friends with https://github.com/osmlab/field-data-collection/pull/118