### PR TITLE
Persist osm import meta

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,2 +1,3 @@
 module.exports.osmapi = 'http://api.openstreetmap.org/api/0.6/'
 module.exports.styleUrl = 'https://openmaptiles.github.io/osm-bright-gl-style/style-cdn.json'
+module.exports.osmMetaFilename = 'osm_import_meta.json'

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -9,9 +9,11 @@ const expressWs = require('express-ws')
 const websocketStreamify = require('websocket-stream')
 const Bonjour = require('bonjour')
 const eos = require('end-of-stream')
+const storage = require('electron-json-storage')
 
 const db = require('./db')
 const { listSurveys, readSurvey } = require('./surveys')
+const { osmMetaFilename } = require('../config')
 
 function Server (opts) {
   if (!(this instanceof Server)) return new Server(opts)
@@ -109,6 +111,18 @@ function Server (opts) {
         req.params.id + '.tgz'
       )
     )
+  })
+
+  app.get('/osm/meta', function (req, res, next) {
+    storage.get(osmMetaFilename, (err, meta) => {
+      if (err) {
+        return next(err)
+      } else if (!meta.hasOwnProperty('uuid')) {
+        return res.sendStatus(404)
+      } else {
+        return res.json(meta)
+      }
+    })
   })
 
   app.ws('/replicate/observations', function (ws) {

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,7 @@
     "bonjour": "^3.5.0",
     "concat-stream": "^1.6.0",
     "drag-drop": "^2.13.2",
+    "electron-json-storage": "^3.0.6",
     "electron-settings": "^3.1.1",
     "end-of-stream": "^1.4.0",
     "es6-promisify": "^5.0.0",

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -35,7 +35,7 @@ function * getOsm ({bounds}) {
     yield call(persist, osmMetaFilename, {
       bounds,
       timestamp,
-      uuid: `${timestamp}__${bounds.join(',')}__${randombytes(8).toString('hex')}`
+      uuid: `${timestamp}__${bbox}__${randombytes(8).toString('hex')}`
     })
     yield put({ type: 'OSM_QUERY_SUCCESS', bounds })
   } catch (error) {

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -1,5 +1,7 @@
 'use strict'
-
+const promisify = require('es6-promisify')
+const persist = promisify(require('electron-json-storage').set)
+const randombytes = require('randombytes')
 const {
   call,
   put,
@@ -13,6 +15,7 @@ const {
   importSurvey,
   importOsm
 } = require('../drivers/local')
+const { osmMetaFilename } = require('../config')
 
 function * getObservations () {
   try {
@@ -28,6 +31,12 @@ function * getOsm ({bounds}) {
   const bbox = bounds.join(',')
   try {
     yield call(importOsm, bbox)
+    const timestamp = new Date().toISOString()
+    yield call(persist, osmMetaFilename, {
+      bounds,
+      timestamp,
+      uuid: `${timestamp}__${bounds.join(',')}__${randombytes(8).toString('hex')}`
+    })
     yield put({ type: 'OSM_QUERY_SUCCESS', bounds })
   } catch (error) {
     yield put({ type: 'OSM_QUERY_FAILED', error })

--- a/src/yarn.lock
+++ b/src/yarn.lock
@@ -219,7 +219,7 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
-async@^2.3.0, async@^2.4.0, async@^2.4.1:
+async@^2.0.0, async@^2.3.0, async@^2.4.0, async@^2.4.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
@@ -687,6 +687,16 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+electron-json-storage@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/electron-json-storage/-/electron-json-storage-3.0.6.tgz#ea1b9a08b68f894d17ae0b4db8a492fc2c2b192c"
+  dependencies:
+    async "^2.0.0"
+    lodash "^4.0.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.5.1"
+    rwlock "^5.0.0"
 
 electron-settings@^3.1.1:
   version "3.1.1"
@@ -1625,7 +1635,7 @@ lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
 
-lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1:
+lodash@^4.0.1, lodash@^4.14.0, lodash@^4.2.0, lodash@^4.2.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1955,6 +1965,22 @@ osm-p2p-db-importer@^1.0.0:
     lexicographic-integer "^1.1.0"
     osm2json "^2.1.0"
     randombytes "^2.0.3"
+
+osm-p2p-db-importer@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/osm-p2p-db-importer/-/osm-p2p-db-importer-1.1.1.tgz#18ea6867d4e522c5d8a002ca714b7cc11f6b781a"
+  dependencies:
+    base-convertor "^1.1.0"
+    collect-stream "^1.2.1"
+    cuid "^1.3.8"
+    end-of-stream "^1.4.0"
+    hyperlog "^4.12.1"
+    level "^1.6.0"
+    lexicographic-integer "^1.1.0"
+    mkdirp "^0.5.1"
+    osm2json "^2.1.0"
+    randombytes "^2.0.3"
+    through2 "^2.0.3"
 
 osm-p2p-db@^4.0.0:
   version "4.0.0"
@@ -2484,6 +2510,10 @@ run-parallel@^1.0.0, run-parallel@^1.1.6:
 run-waterfall@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/run-waterfall/-/run-waterfall-1.1.3.tgz#d96fc0f5361bcbdbd438529dc8a4b42fc6761123"
+
+rwlock@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rwlock/-/rwlock-5.0.0.tgz#888d6a77a3351cc1a209204ef2ee1722093836cf"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"


### PR DESCRIPTION
Create osm metadata on import and persist it locally, and make it available to mobile apps via endpoint.

Close #36 

The endpoint at `/osm/meta` will either `404` if there's no geography set, or a json object `{ bounds, timestamp, uuid }`, where `uuid` is the timestamp + bounds + some random bytes.