### PR TITLE
fix: Use the correct method name in the server.

### DIFF
--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -134,7 +134,7 @@ function Server (opts) {
 
   app.ws('/replicate/osm', function (ws) {
     ws = websocketStreamify(ws)
-    var stream = db.getOsmOrgXmlStream()
+    var stream = db.getLocalOsmOrgXmlStream()
     if (!stream) {
       ws.end()
     } else {


### PR DESCRIPTION
Fixes method name typo.