### PR TITLE
Add helpers for getting observations

### DIFF
--- a/src/lib/observations.js
+++ b/src/lib/observations.js
@@ -1,0 +1,89 @@
+const amap = require('async').map
+const through = require('through2')
+const concat = require('concat-stream')
+
+module.exports = {
+  getObservationsByNode,
+  getObservationsBySurveyId,
+  getObservationsByDeviceId
+}
+
+function getObservationsByNode (nodeId, observationsDb, observationsIndex, cb) {
+  observationsIndex.links(nodeId, function (err, docs) {
+    if (err) return cb(err)
+
+    amap(docs, observationLinkToObservation, function (err, res) {
+      if (err) return cb(err)
+      res = res.filter(item => !!item)
+      cb(null, res)
+    })
+
+    function observationLinkToObservation (link, done) {
+      var obsId = link.value.obs
+      observationsDb.get(obsId, function (err, heads) {
+        if (err) return done(err)
+        var doc = flattenHeads(heads)
+        done(null, doc)
+      })
+    }
+  })
+}
+
+function getObservationsBySurveyId (surveyId, observationsDb, cb) {
+  filterAllDocuments(observationsDb, match, cb)
+
+  function match (doc) {
+    return doc.tags && doc.tags.surveyId && doc.tags.surveyId == surveyId
+  }
+}
+
+function getObservationsByDeviceId (deviceId, observationsDb, cb) {
+  filterAllDocuments(observationsDb, match, cb)
+
+  function match (doc) {
+    return doc.tags && doc.tags.deviceId && doc.tags.deviceId == deviceId
+  }
+}
+
+function filterAllDocuments (observationsDb, filterFn, cb) {
+  var q = observationsDb.queryStream([[-90, 90], [-180, 180]])
+  var t = through.obj(write)
+  var sink = concat({encoding: 'object'}, onValues)
+
+  q.pipe(t).pipe(sink)
+
+  function onValues (values) {
+    cb(null, values)
+  }
+
+  function write (doc, _, next) {
+    if (filterFn(doc)) {
+      this.push(doc)
+    }
+    next()
+  }
+}
+
+function flattenHeads (heads) {
+  var keys = Object.keys(heads)
+  if (keys.length === 0) return null
+  return values(heads).sort(cmpFork)[0]
+}
+
+function values (obj) { return Object.keys(obj).map(k => obj[k]) }
+
+/**
+ * Sort function to sort forks by most recent first, or by version id
+ * if no timestamps are set
+ */
+function cmpFork (a, b) {
+  if (a.timestamp && b.timestamp) {
+    if (a.timestamp > b.timestamp) return -1
+    if (a.timestamp < b.timestamp) return 1
+    return 0
+  }
+  if (a.timestamp) return -1
+  if (b.timestamp) return 1
+  // Ensure sorting is stable between requests
+  return a.version < b.version ? -1 : 1
+}

--- a/src/lib/observations.js
+++ b/src/lib/observations.js
@@ -33,7 +33,7 @@ function getObservationsBySurveyId (surveyId, observationsDb, cb) {
   filterAllDocuments(observationsDb, match, cb)
 
   function match (doc) {
-    return doc.tags && doc.tags.surveyId && doc.tags.surveyId == surveyId
+    return doc.tags && doc.tags.surveyId && doc.tags.surveyId.toString() === surveyId.toString()
   }
 }
 
@@ -41,7 +41,7 @@ function getObservationsByDeviceId (deviceId, observationsDb, cb) {
   filterAllDocuments(observationsDb, match, cb)
 
   function match (doc) {
-    return doc.tags && doc.tags.deviceId && doc.tags.deviceId == deviceId
+    return doc.tags && doc.tags.deviceId && doc.tags.deviceId.toString() === deviceId.toString()
   }
 }
 

--- a/test/observations.js
+++ b/test/observations.js
@@ -1,5 +1,4 @@
 var test = require('tape')
-var series = require('run-series')
 var osmdb = require('osm-p2p-mem')
 var obsdb = require('osm-p2p-observations')
 var memdb = require('memdb')
@@ -55,7 +54,6 @@ test('get observations by node', function (t) {
 test('get observations by survey id, device id', function (t) {
   // Set up a new test db
   var observationsDb = osmdb()
-  var observationsIndex = obsdb({ db: memdb(), log: observationsDb.log })
 
   var docs = {
     A: {

--- a/test/observations.js
+++ b/test/observations.js
@@ -1,0 +1,115 @@
+var test = require('tape')
+var series = require('run-series')
+var osmdb = require('osm-p2p-mem')
+var obsdb = require('osm-p2p-observations')
+var memdb = require('memdb')
+var helpers = require('../src/lib/observations')
+var forEach = require('async').forEach
+
+test('get observations by node', function (t) {
+  // Set up a new test db
+  var observationsDb = osmdb()
+  var observationsIndex = obsdb({ db: memdb(), log: observationsDb.log })
+
+  var docs = {
+    A: {
+      type: 'observation',
+      lat: 1,
+      lon: 1
+    },
+    B: {
+      type: 'observation',
+      lat: 2,
+      lon: 2
+    },
+    C: {
+      type: 'observation-link',
+      link: 'E',
+      obs: 'A'
+    },
+    D: {
+      type: 'observation-link',
+      link: 'E',
+      obs: 'B'
+    }
+  }
+
+  forEach(Object.keys(docs).sort(), insertDoc, checkObservations)
+
+  function insertDoc (docId, cb) {
+    observationsDb.put(docId, docs[docId], cb)
+  }
+
+  function checkObservations (err) {
+    t.error(err)
+
+    helpers.getObservationsByNode('E', observationsDb, observationsIndex, function (err, res) {
+      t.error(err)
+      var expected = [ { lat: 1, lon: 1, type: 'observation' }, { lat: 2, lon: 2, type: 'observation' } ]
+      t.deepEqual(res, expected)
+      t.end()
+    })
+  }
+})
+
+test('get observations by survey id, device id', function (t) {
+  // Set up a new test db
+  var observationsDb = osmdb()
+  var observationsIndex = obsdb({ db: memdb(), log: observationsDb.log })
+
+  var docs = {
+    A: {
+      type: 'observation',
+      lat: 1,
+      lon: 1,
+      tags: {
+        surveyId: '123',
+        deviceId: 'dead'
+      }
+    },
+    B: {
+      type: 'observation',
+      lat: 2,
+      lon: 2,
+      tags: {
+        surveyId: '200',
+        deviceId: 'beef'
+      }
+    },
+    C: {
+      type: 'observation',
+      lat: 3,
+      lon: 3
+    }
+  }
+
+  forEach(Object.keys(docs).sort(), insertDoc, checkObservations)
+
+  function insertDoc (docId, cb) {
+    observationsDb.put(docId, docs[docId], cb)
+  }
+
+  function checkObservations (err) {
+    t.error(err)
+
+    helpers.getObservationsBySurveyId('123', observationsDb, function (err, res) {
+      t.error(err)
+      t.equal(res.length, 1)
+      var expected = [ docs.A ]
+      delete res[0].version
+      delete res[0].id
+      t.deepEqual(res, expected)
+
+      helpers.getObservationsByDeviceId('beef', observationsDb, function (err, res) {
+        t.error(err)
+        t.equal(res.length, 1)
+        var expected = [ docs.B ]
+        delete res[0].version
+        delete res[0].id
+        t.deepEqual(res, expected)
+
+        t.end()
+      })
+    })
+  }
+})


### PR DESCRIPTION
Some helper functions for fetching observations by

1. Node ID
2. Device ID
3. Survey ID

@dereklieu @sethvincent Are these all useful? Are there others you'd like? We can use this module in both the coordinator and the collector.