### PR TITLE
Use app-specific subdirectory for app data

### DIFF
--- a/src/lib/app-path.js
+++ b/src/lib/app-path.js
@@ -3,7 +3,8 @@ const path = require('path')
 const fs = require('fs')
 const { app } = require('electron')
 
-const APP_DIR = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8')).name
+const APP_DIR = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf-8')).name
+process.stdout.write(APP_DIR + '\n')
 
 module.exports = function () {
   var dir = app.getPath('userData')

--- a/src/lib/app-path.js
+++ b/src/lib/app-path.js
@@ -1,0 +1,12 @@
+const mkdirp = require('mkdirp')
+const path = require('path')
+const { app } = require('electron')
+
+const APP_DIR = 'org.osm-labs.field-data-coordinator'
+
+module.exports = function () {
+  var dir = path.join(app.getPath('userData'), APP_DIR)
+  mkdirp.sync(dir)
+  return dir
+}
+

--- a/src/lib/app-path.js
+++ b/src/lib/app-path.js
@@ -17,4 +17,3 @@ module.exports = function () {
 
   return dir
 }
-

--- a/src/lib/app-path.js
+++ b/src/lib/app-path.js
@@ -5,8 +5,16 @@ const { app } = require('electron')
 const APP_DIR = 'org.osm-labs.field-data-coordinator'
 
 module.exports = function () {
-  var dir = path.join(app.getPath('userData'), APP_DIR)
+  var dir = app.getPath('userData')
+
+  // Development mode doesn't include the APP_DIR subdirectory, but production
+  // does.
+  if (dir.indexOf(APP_DIR) !== -1) {
+    dir = path.join(dir, APP_DIR)
+  }
+
   mkdirp.sync(dir)
+
   return dir
 }
 

--- a/src/lib/app-path.js
+++ b/src/lib/app-path.js
@@ -1,8 +1,9 @@
 const mkdirp = require('mkdirp')
 const path = require('path')
+const fs = require('fs')
 const { app } = require('electron')
 
-const APP_DIR = 'org.osm-labs.field-data-coordinator'
+const APP_DIR = JSON.parse(fs.readFileSync(path.join(__dirname, 'package.json'), 'utf-8')).name
 
 module.exports = function () {
   var dir = app.getPath('userData')

--- a/src/lib/surveys.js
+++ b/src/lib/surveys.js
@@ -4,7 +4,6 @@ const fs = require('fs')
 const path = require('path')
 
 const async = require('async')
-const { app } = require('electron')
 const eos = require('end-of-stream')
 const JSONStream = require('JSONStream')
 const mkdirp = require('mkdirp')

--- a/src/lib/surveys.js
+++ b/src/lib/surveys.js
@@ -11,19 +11,20 @@ const mkdirp = require('mkdirp')
 const once = require('once')
 const slugify = require('slugify')
 const tar = require('tar-stream')
+const appPath = require('./app-path')
 
 function bundleSurvey (surveyDefinition, callback) {
   const bundle = tar.pack()
   const { name, version } = surveyDefinition
   const filename = `${slugify(name)}-${version}.tgz`
 
-  mkdirp(path.join(app.getPath('userData'), 'surveys'), err => {
+  mkdirp(path.join(appPath(), 'surveys'), err => {
     if (err) {
       return callback(err)
     }
 
     const output = fs.createWriteStream(
-      path.join(app.getPath('userData'), 'surveys', filename)
+      path.join(appPath(), 'surveys', filename)
     )
 
     // call the callback when the stream ends, one way or another
@@ -42,7 +43,7 @@ function bundleSurvey (surveyDefinition, callback) {
 }
 
 const listSurveys = function (callback) {
-  const surveyPath = path.join(app.getPath('userData'), 'surveys')
+  const surveyPath = path.join(appPath(), 'surveys')
 
   return fs.stat(surveyPath, (err, stats) => {
     if (err) {
@@ -78,7 +79,7 @@ const readSurvey = (filename, callback) => {
     filename += '.tgz'
   }
 
-  filename = path.join(app.getPath('userData'), 'surveys', filename)
+  filename = path.join(appPath(), 'surveys', filename)
 
   return fs.stat(filename, (err, stats) => {
     if (err) {

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,8 @@ const { bundleSurvey, listSurveys } = require('./lib/surveys')
 const { updateSurveyList } = require('./actions')
 const exportObservations = require('./lib/export')
 
+const appPath = require('./lib/app-path')
+
 let main
 let dispatch = () => console.warn('dispatch not yet connected')
 
@@ -64,7 +66,7 @@ function setupMenu () {
   // https://github.com/electron/electron/blob/master/docs/api/menu.md#main-process
 }
 
-const dbPath = path.join(app.getPath('userData'), 'db')
+const dbPath = path.join(appPath(), 'db')
 mkdirp.sync(dbPath)
 db.start(dbPath)
 


### PR DESCRIPTION
Previously the app would dump all of its data directly into
`~/.config/Electron` (or `%APPDATA%\Electron` on Windows). With generic names
like `db` and `surveys` there's a good chance of colliding with other Electron
apps' data.