### PR TITLE
Fix display of downloaded area, match dimensions to frame

### DIFF
--- a/src/ui/surveys/Current-Selection.jsx
+++ b/src/ui/surveys/Current-Selection.jsx
@@ -47,7 +47,7 @@ class CurrentSelection extends React.Component {
         <div className='metadataWrapper'>
           <h4>Imported Geographic Area</h4>
           <p className='metadata'>Coordinates: {bounds.map(b => b.toFixed(5)).join(', ')}</p>
-          <p className='metadata'>Area: {(calculateArea(bboxPolygon(bounds)) / 1000).toFixed(2)} km<sup>2</sup></p>
+          <p className='metadata'>Area: {Math.sqrt((calculateArea(bboxPolygon(bounds)) / 1000)).toFixed(2)} km<sup>2</sup></p>
         </div>
       </div>
     )

--- a/src/ui/surveys/Select-Geography.jsx
+++ b/src/ui/surveys/Select-Geography.jsx
@@ -113,8 +113,6 @@ class SelectGeography extends React.Component {
     const { mapWidth, mapHeight, mapBounds } = this.state
     // calculate viewport area in square meters
     const viewportArea = calculateArea(bboxPolygon(mapBounds))
-    console.log(viewportArea)
-    console.log(MAX_AREA)
     // calculate the length of the edge, given a constant maximum area
     const viewportEdge = Math.min(mapWidth, mapHeight)
     const ratio = viewportArea < MAX_AREA ? 1

--- a/src/ui/surveys/Select-Geography.jsx
+++ b/src/ui/surveys/Select-Geography.jsx
@@ -114,7 +114,6 @@ class SelectGeography extends React.Component {
     // calculate viewport area in square meters
     const viewportArea = calculateArea(bboxPolygon(mapBounds))
     // calculate the length of the edge, given a constant maximum area
-    const viewportEdge = Math.min(mapWidth, mapHeight)
     const ratio = viewportArea < MAX_AREA ? 1
       : Math.sqrt(MAX_AREA / viewportArea)
     return { width: mapWidth * ratio, height: mapHeight * ratio }

--- a/src/ui/surveys/Select-Geography.jsx
+++ b/src/ui/surveys/Select-Geography.jsx
@@ -113,12 +113,13 @@ class SelectGeography extends React.Component {
     const { mapWidth, mapHeight, mapBounds } = this.state
     // calculate viewport area in square meters
     const viewportArea = calculateArea(bboxPolygon(mapBounds))
+    console.log(viewportArea)
+    console.log(MAX_AREA)
     // calculate the length of the edge, given a constant maximum area
     const viewportEdge = Math.min(mapWidth, mapHeight)
     const ratio = viewportArea < MAX_AREA ? 1
-      : Math.sqrt(MAX_AREA) / Math.sqrt(viewportArea)
-    const edge = viewportEdge * ratio
-    return { width: edge, height: edge }
+      : Math.sqrt(MAX_AREA / viewportArea)
+    return { width: mapWidth * ratio, height: mapHeight * ratio }
   }
 
   getStyle () {


### PR DESCRIPTION
This makes the downloaded OSM area slightly larger, and actually shows you the right area in square kilometers rather than the outrageously inflated number it showed before.

cc @felskia 